### PR TITLE
Define `INTELLLVM_` if FC is IntelLLVM (oneAPI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ list(APPEND NECI_GLOBAL_DEFINES
 
     # Identify the compiler to the code
     $<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},Intel>:IFORT_>
+    $<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},IntelLLVM>:INTELLLVM_>
     $<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},GNU>:GFORTRAN_>
     $<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},PGI>:PGI_>
 )

--- a/src/lib/cons_neci.F90
+++ b/src/lib/cons_neci.F90
@@ -36,7 +36,7 @@ module constants
     integer, parameter :: sizeof_int32 = sizeof(0_int32)
     integer, parameter :: sizeof_int64 = sizeof(0_int64)
     integer, parameter :: sizeof_dp = sizeof(0._dp)
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
     integer, parameter :: sizeof_complexdp = 2 * sizeof_dp
 #else
     integer, parameter :: sizeof_complexdp = sizeof(complex(0._dp, 0._dp))

--- a/src/lib/util_mod.fpp
+++ b/src/lib/util_mod.fpp
@@ -23,7 +23,7 @@ module util_mod
 
     ! We want to use the builtin etime intrinsic with ifort to
     ! work around some broken behaviour.
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
     use ifport, only: etime
 #endif
     implicit none
@@ -581,14 +581,14 @@ contains
                         if (signal_overflow) then
                             res = -1
                         else
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
                             error stop 'Binomial coefficient exceeds range of int64.'
 #else
                             call stop_all(this_routine, 'Binomial coefficient exceeds range of int64.')
 #endif
                         end if
                     else
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
                             error stop 'Binomial coefficient exceeds range of int64.'
 #else
                             call stop_all(this_routine, 'Binomial coefficient exceeds range of int64.')
@@ -641,14 +641,14 @@ contains
                         if (signal_overflow) then
                             res = -1
                         else
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
                             error stop 'Binomial coefficient exceeds range of int128.'
 #else
                             call stop_all(this_routine, 'Binomial coefficient exceeds range of int128.')
 #endif
                         end if
                     else
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
                             error stop 'Binomial coefficient exceeds range of int128.'
 #else
                             call stop_all(this_routine, 'Binomial coefficient exceeds range of int128.')
@@ -1217,7 +1217,7 @@ contains
     end subroutine find_next_comb
 
     function neci_etime(time) result(ret)
-#ifndef IFORT_
+#if !defined(IFORT_) && !defined(INTELLLVM_)
         use mpi
 #endif
         ! Return elapsed time for timing and calculation ending purposes.
@@ -1225,7 +1225,7 @@ contains
         real(dp), intent(out) :: time(2)
         real(dp) :: ret
 
-#ifdef IFORT_
+#if defined(IFORT_) || defined(INTELLLVM_)
         ! intels etime takes a real(4)
         real(4) :: ioTime(2)
         ! Ifort defines etime directly in its compatibility modules.


### PR DESCRIPTION
With intel oneAPI compilers, I encounter the following build error:
```
…
Input file: /tmp/src/lib/util_mod_cpts.F90.template
Output file: /tmp/build/templated/libneci/util_mod_cpts.F90
Producing configurations: 
int, int64, real, doub, logical, cplx, cplx_doub, sym, sympairprodGenerating super module: util_mod_cpts
Interface generation
Procedure:  arr_2d_dims
Procedure:  arr_2d_ptr
Procedure:  ptr_abuse_1d
Procedure:  ptr_abuse_2d
Procedure:  ptr_abuse_scalar
Scanning dependencies of target libneci
[  2%] Building Fortran object src/CMakeFiles/libneci.dir/lib/cons_neci.F90.o
/tmp/src/lib/cons_neci.F90(42): error #6404: This name does not have a type, and must have an explicit type.   [COMPLEX]
    integer, parameter :: sizeof_complexdp = sizeof(complex(0._dp, 0._dp))
----------------------------------------------------^
/tmp/src/lib/cons_neci.F90(42): error #7058: This SIZEOF function call cannot appear in an initialization expression.   [SIZEOF]
    integer, parameter :: sizeof_complexdp = sizeof(complex(0._dp, 0._dp))
---------------------------------------------^
compilation aborted for /tmp/src/lib/cons_neci.F90 (code 1)
make[2]: *** [src/CMakeFiles/libneci.dir/build.make:2892: src/CMakeFiles/libneci.dir/lib/cons_neci.F90.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1603: src/CMakeFiles/libneci.dir/all] Error 2
make: *** [Makefile:101: all] Error 2

```